### PR TITLE
NDS-193 (configurable timeout) and cleanup

### DIFF
--- a/apiserver/README.md
+++ b/apiserver/README.md
@@ -66,16 +66,9 @@ Address=localhost:4001
 [Kubernetes]
 Address=localhost:8080
 
-[OpenStack]
-Username=
-Password=
-TenantId=
-IdentityEndpoint=http://nebula.ncsa.illinois.edu:5000/v2.0/
-VolumesEndpoint=http://nebula.ncsa.illinois.edu:8776/v2/
-ComputeEndpoint=http://nebula.ncsa.illinois.edu:8774/v2/
 ```
 
-If VolumeSource is "local", a local directory is used for hostPath volumes in Kubernetes. If "openstack", volumes are created via the OpenStack API.
+If VolumeSource is "local", a local directory is used for hostPath volumes in Kubernetes. 
 
 
 ### Running the server

--- a/apiserver/apiserver.conf
+++ b/apiserver/apiserver.conf
@@ -1,12 +1,12 @@
 [Server]
-Port=8083
+Port=30001
 Origin=
 VolDir=/tmp/volumes
-Host=localhost
 VolumeSource=local
+#Timeout=1
 
 [Etcd]
 Address=localhost:4001
 [Kubernetes]
-Address=localhost:8080
+Address=http://localhost:8080
 

--- a/apiserver/apiserver.conf
+++ b/apiserver/apiserver.conf
@@ -10,10 +10,3 @@ Address=localhost:4001
 [Kubernetes]
 Address=localhost:8080
 
-[OpenStack]
-Username=
-Password=
-TenantId=
-IdentityEndpoint=http://nebula.ncsa.illinois.edu:5000/v2.0/
-VolumesEndpoint=http://nebula.ncsa.illinois.edu:8776/v2/
-ComputeEndpoint=http://nebula.ncsa.illinois.edu:8774/v2/

--- a/apiserver/kube/kube.go
+++ b/apiserver/kube/kube.go
@@ -104,6 +104,43 @@ func (k *KubeHelper) CreateNamespace(pid string) (*api.Namespace, error) {
 	return nil, nil
 }
 
+func (k *KubeHelper) GetNamespace(pid string) (*api.Namespace, error) {
+
+	url := k.kubeBase + apiBase + "/namespaces/" + pid
+	glog.V(4).Infoln(url)
+	request, _ := http.NewRequest("GET", url, nil)
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", fmt.Sprintf("Basic %s", k.basicAuth))
+	httpresp, httperr := k.client.Do(request)
+	if httperr != nil {
+		glog.Error(httperr)
+		return nil, httperr
+	} else {
+		if httpresp.StatusCode == http.StatusOK {
+			data, err := ioutil.ReadAll(httpresp.Body)
+			if err != nil {
+				return nil, err
+			}
+
+			ns := api.Namespace{}
+			json.Unmarshal(data, &ns)
+			return &ns, nil
+		} else {
+			return nil, fmt.Errorf("Error getting namespace for project %s: %s\n", pid, httpresp.Status)
+		}
+	}
+	return nil, nil
+}
+
+func (k *KubeHelper) NamespaceExists(pid string) bool {
+	ns, _ := k.GetNamespace(pid)
+	if ns != nil {
+		return true
+	} else {
+		return false
+	}
+}
+
 func (k *KubeHelper) DeleteNamespace(pid string) (*api.Namespace, error) {
 
 	url := k.kubeBase + apiBase + "/namespaces/" + pid


### PR DESCRIPTION
- Added Timeout config option
- Fixed problem with initExistingProjects where namespace doesn't exist after restart (sometimes occurs when Kubernetes is restarted in development)
- Removed unused config options (e.g., Openstack)
